### PR TITLE
[IMPROVEMENT] Upgraded symfony/serializer version from 2.7 to 3.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "illuminate/support": "5.4.*",
     "illuminate/validation": "5.4.*",
     "illuminate/view": "5.4.*",
-    "symfony/serializer": "^2.7"
+    "symfony/serializer": "^3.3"
   },
   "require-dev": {
     "phpunit/phpunit": "~5.0",


### PR DESCRIPTION
In order to use DateTimeNormalizer is necessary to upgrade the symfony/serializer versiont from 2.7 to 3.x

### Changes proposed in this pull request:
- changed symfony/serializer dependence from ^2.7 to ^3.3